### PR TITLE
Tour stop breakfast vs. dinner

### DIFF
--- a/lib/tourin_it/tour_stops/tour_stop.ex
+++ b/lib/tourin_it/tour_stops/tour_stop.ex
@@ -6,6 +6,7 @@ defmodule TourinIt.TourStops.TourStop do
 
   schema "tour_stops" do
     field :destination, :string
+    field :occasion, Ecto.Enum, default: :dinner, values: [:breakfast, :dinner]
     field :start_date, :date
     field :end_date, :date
 
@@ -19,14 +20,14 @@ defmodule TourinIt.TourStops.TourStop do
   @doc false
   def changeset(tour_stop, attrs) do
     tour_stop
-    |> cast(attrs, [:destination, :start_date, :end_date, :tour_session_id])
-    |> validate_required([:destination, :start_date, :end_date, :tour_session_id])
+    |> cast(attrs, [:destination, :occasion, :start_date, :end_date, :tour_session_id])
+    |> validate_required([:destination, :occasion, :start_date, :end_date, :tour_session_id])
   end
 
   @doc false
   def update_changeset(tour_stop, attrs) do
     tour_stop
-    |> cast(attrs, [:destination, :start_date, :end_date])
-    |> validate_required([:destination, :start_date, :end_date])
+    |> cast(attrs, [:destination, :occasion, :start_date, :end_date])
+    |> validate_required([:destination, :occasion, :start_date, :end_date])
   end
 end

--- a/lib/tourin_it_web/components/navbar.ex
+++ b/lib/tourin_it_web/components/navbar.ex
@@ -10,9 +10,7 @@ defmodule TourinItWeb.Navbar do
         <img src={~p"/images/logo.svg"} width="36" />
         <p class="font-medium leading-6">
           <span :if={@current_user} class="capitalize mr-4">Hello, {@current_user.username}</span>
-          <span :if={@current_user && @current_user.admin} class="underline mr-4">
-            <.link navigate={~p"/organize/tours"}>Admin</.link>
-          </span>
+          <.link :if={@current_user && @current_user.admin} class="underline mr-4" navigate={~p"/organize/tours"}>Admin</.link>
           <span class="bg-brand/5 text-brand rounded-full px-2">
             v{Application.spec(:tourin_it, :vsn)}
           </span>

--- a/lib/tourin_it_web/components/tour_stop_components.ex
+++ b/lib/tourin_it_web/components/tour_stop_components.ex
@@ -3,12 +3,25 @@ defmodule TourinItWeb.TourStopComponents do
 
   alias TourinIt.TourStops.TourStop
 
+  attr :tour_stop, TourStop, required: true
+  def tour_stop_details(assigns) do
+    ~H"""
+      <p class="font-semibold mb-8 text-zinc-700">
+        {format_date(@tour_stop.start_date)} - {format_date(@tour_stop.end_date)}
+      </p>
+      <p class="font-semibold mb-2 text-zinc-700">{@tour_stop.destination}</p>
+      <p class="mb-8 text-zinc-500">
+        <.tour_stop_occasion occasion={@tour_stop.occasion} />
+      </p>
+    """
+  end
+
   attr :occasion, :atom, required: true, values: Ecto.Enum.values(TourStop, :occasion)
   def tour_stop_occasion(assigns) do
     ~H"""
     <span class="capitalize">
-      {raw(occasion_emoji(assigns.occasion))}
-      {assigns.occasion}
+      {raw(occasion_emoji(@occasion))}
+      {@occasion}
     </span>
     """
   end

--- a/lib/tourin_it_web/components/tour_stop_components.ex
+++ b/lib/tourin_it_web/components/tour_stop_components.ex
@@ -1,0 +1,36 @@
+defmodule TourinItWeb.TourStopComponents do
+  use TourinItWeb, :html
+
+  alias TourinIt.TourStops.TourStop
+
+  attr :occasion, :atom, required: true, values: Ecto.Enum.values(TourStop, :occasion)
+  def tour_stop_occasion(assigns) do
+    ~H"""
+    <span class="capitalize">
+      {raw(occasion_emoji(assigns.occasion))}
+      {assigns.occasion}
+    </span>
+    """
+  end
+
+  defp occasion_emoji(occasion) do
+    case occasion do
+      :breakfast ->
+        Enum.random([
+          "&#127849;",
+          "&#129363;",
+          "&#129374;",
+          "&#129479;"
+        ])
+      :dinner ->
+        Enum.random([
+          "&#127790;",
+          "&#127828;",
+          "&#127831;",
+          "&#127837;",
+          "&#127843;",
+          "&#129385;"
+        ])
+    end
+  end
+end

--- a/lib/tourin_it_web/live/organize/tour_session_live.ex
+++ b/lib/tourin_it_web/live/organize/tour_session_live.ex
@@ -13,6 +13,10 @@ defmodule TourinItWeb.Organize.TourSessionLive do
     <.back navigate={~p"/organize/tours/#{@tour_session.tour}"}>Back to {@tour_session.tour.name}</.back>
     <.header class="mb-8">Tour Session {@tour_session.identifier}</.header>
 
+    <div class="mb-8">
+      <.link class="underline" target="_blank" navigate={~p"/tours/#{@tour_session.tour.slug}/#{@tour_session.identifier}"}>View as tour goer</.link>
+    </div>
+
     <.live_component module={TourStopsComponent} id="tour_stops" tour_session={@tour_session} />
 
     <hr class="mt-8 mb-16" />

--- a/lib/tourin_it_web/live/organize/tour_stop_form.html.heex
+++ b/lib/tourin_it_web/live/organize/tour_stop_form.html.heex
@@ -1,5 +1,6 @@
 <.form :let={f} for={@changeset} phx-submit="save" phx-target={@target} class="contents">
   <.input field={f[:destination]} label="Destination" />
+  <.input field={f[:occasion]} label="Occasion" type="select" options={occasion_options()} />
   <.input field={f[:start_date]} label="Start date" type="date" />
   <.input field={f[:end_date]} label="End date" type="date" />
   <span class="justify-self-center self-end">

--- a/lib/tourin_it_web/live/organize/tour_stops_component.ex
+++ b/lib/tourin_it_web/live/organize/tour_stops_component.ex
@@ -70,6 +70,10 @@ defmodule TourinItWeb.Organize.TourStopsComponent do
     {:noreply, reload_tour_session(socket)}
   end
 
+  def occasion_options() do
+    Ecto.Enum.values(TourStop, :occasion)
+  end
+
   defp changeset(%TourStop{} = tour_stop), do: TourStops.change_tour_stop(tour_stop)
 
   defp reload_tour_session(socket) do

--- a/lib/tourin_it_web/live/organize/tour_stops_component.html.heex
+++ b/lib/tourin_it_web/live/organize/tour_stops_component.html.heex
@@ -1,18 +1,20 @@
 <section>
   <p class="mb-6 leading-6 text-zinc-800">Tour stops</p>
   <div class="flex flex-col mb-4">
-    <div class="grid grid-cols-4 gap-4 text-sm text-zinc-500 border-b border-zinc-200 pb-4 mb-4">
+    <div class="grid grid-cols-5 gap-4 text-sm text-zinc-500 border-b border-zinc-200 pb-4 mb-4">
       <div>Destination</div>
+      <div>Occasion</div>
       <div>Start date</div>
       <div>End date</div>
       <div><!-- Actions --></div>
     </div>
-    <div :for={tour_stop <- @tour_session.tour_stops} class="grid grid-cols-4 gap-4 mb-4">
+    <div :for={tour_stop <- @tour_session.tour_stops} class="grid grid-cols-5 gap-4 mb-4">
       <div :if={!@editing_tour_stops[Integer.to_string(tour_stop.id)]} class="contents">
         <div>{tour_stop.destination}</div>
+        <div>{tour_stop.occasion}</div>
         <div>{tour_stop.start_date}</div>
         <div>{tour_stop.end_date}</div>
-        <div class="flex gap-4">
+        <div class="flex gap-4 underline">
           <.link navigate={~p"/tour_stops/#{tour_stop}"}>View</.link>
           <button type="button" phx-click="edit" phx-value-id={tour_stop.id} phx-target={@myself}>Edit</button>
           <button type="button" phx-click="delete" phx-value-id={tour_stop.id} phx-target={@myself}>Delete</button>

--- a/lib/tourin_it_web/live/tour_stop_live/index.ex
+++ b/lib/tourin_it_web/live/tour_stop_live/index.ex
@@ -2,6 +2,7 @@ defmodule TourinItWeb.TourStopLive.Index do
   use TourinItWeb, :live_view
 
   import TourinItWeb.Access.TourGoer
+  import TourinItWeb.TourStopComponents
 
   alias TourinIt.{Organize, Repo}
 

--- a/lib/tourin_it_web/live/tour_stop_live/index.html.heex
+++ b/lib/tourin_it_web/live/tour_stop_live/index.html.heex
@@ -2,6 +2,9 @@
 
 <.table id="tour_stops" rows={@tour_session.tour_stops} row_click={&JS.navigate(~p"/tour_stops/#{&1}")}>
   <:col :let={tour_stop} label="Location">{tour_stop.destination}</:col>
+  <:col :let={tour_stop} label={gettext("tour_stop.occasion")}>
+    <.tour_stop_occasion occasion={tour_stop.occasion} />
+  </:col>
   <:col :let={tour_stop} label="Dates">
     {format_date(tour_stop.start_date)} - {format_date(tour_stop.end_date)}
   </:col>

--- a/lib/tourin_it_web/live/tour_stop_live/show.ex
+++ b/lib/tourin_it_web/live/tour_stop_live/show.ex
@@ -2,6 +2,7 @@ defmodule TourinItWeb.TourStopLive.Show do
   use TourinItWeb, :live_view
 
   import TourinItWeb.Access.TourGoer
+  import TourinItWeb.TourStopComponents
 
   alias TourinIt.Repo
   alias TourinIt.{TourDates, TourGoers ,TourStops}

--- a/lib/tourin_it_web/live/tour_stop_live/show.html.heex
+++ b/lib/tourin_it_web/live/tour_stop_live/show.html.heex
@@ -2,10 +2,7 @@
 
 <.header class="mb-8">{@tour_session.tour.name} {@tour_session.identifier}</.header>
 
-<p class="font-semibold mb-8 text-zinc-700">
-  {format_date(@tour_stop.start_date)} - {format_date(@tour_stop.end_date)}
-</p>
-<p class="font-semibold mb-8 text-zinc-700">{@tour_stop.destination}</p>
+<.tour_stop_details tour_stop={@tour_stop} />
 
 <div class="grid grid-cols-6 gap-y-8 text-sm font-semibold text-zinc-700">
   <div class="contents text-center">

--- a/lib/tourin_it_web/live/tour_stop_survey_live/edit.ex
+++ b/lib/tourin_it_web/live/tour_stop_survey_live/edit.ex
@@ -2,6 +2,7 @@ defmodule TourinItWeb.TourStopSurveyLive.Edit do
   use TourinItWeb, :live_view
 
   import TourinItWeb.Access.TourGoer
+  import TourinItWeb.TourStopComponents
 
   alias TourinIt.{Repo, TourDates, TourGoers, TourStops}
 

--- a/lib/tourin_it_web/live/tour_stop_survey_live/edit.html.heex
+++ b/lib/tourin_it_web/live/tour_stop_survey_live/edit.html.heex
@@ -4,10 +4,7 @@
   {@tour_stop.tour_session.tour.name} {@tour_stop.tour_session.identifier}
 </.header>
 
-<p class="font-semibold mb-8 text-zinc-700">
-  {format_date(@tour_stop.start_date)} - {format_date(@tour_stop.end_date)}
-</p>
-<p class="font-semibold mb-8 text-zinc-700">{@tour_stop.destination}</p>
+<.tour_stop_details tour_stop={@tour_stop} />
 
 <.form for={nil} phx-submit="save">
   <div :for={{tour_date, survey} <- @surveys} class="mb-8">

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -1,0 +1,58 @@
+## This file is a PO Template file.
+##
+## "msgid"s here are often extracted from source code.
+## Add new messages manually only if they're dynamic
+## messages that can't be statically extracted.
+##
+## Run "mix gettext.extract" to bring this file up to
+## date. Leave "msgstr"s empty as changing them here has no
+## effect: edit them in PO (.po) files instead.
+#
+msgid ""
+msgstr ""
+
+#: lib/tourin_it_web/components/core_components.ex:492
+#, elixir-autogen, elixir-format
+msgid "Actions"
+msgstr ""
+
+#: lib/tourin_it_web/components/core_components.ex:160
+#, elixir-autogen, elixir-format
+msgid "Attempting to reconnect"
+msgstr ""
+
+#: lib/tourin_it_web/components/core_components.ex:151
+#, elixir-autogen, elixir-format
+msgid "Error!"
+msgstr ""
+
+#: lib/tourin_it_web/components/core_components.ex:172
+#, elixir-autogen, elixir-format
+msgid "Hang in there while we get back on track"
+msgstr ""
+
+#: lib/tourin_it_web/components/core_components.ex:167
+#, elixir-autogen, elixir-format
+msgid "Something went wrong!"
+msgstr ""
+
+#: lib/tourin_it_web/components/core_components.ex:150
+#, elixir-autogen, elixir-format
+msgid "Success!"
+msgstr ""
+
+#: lib/tourin_it_web/components/core_components.ex:155
+#, elixir-autogen, elixir-format
+msgid "We can't find the internet"
+msgstr ""
+
+#: lib/tourin_it_web/components/core_components.ex:76
+#: lib/tourin_it_web/components/core_components.ex:130
+#, elixir-autogen, elixir-format
+msgid "close"
+msgstr ""
+
+#: lib/tourin_it_web/live/tour_stop_live/index.html.heex:5
+#, elixir-autogen, elixir-format
+msgid "tour_stop.occasion"
+msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -1,0 +1,58 @@
+## "msgid"s in this file come from POT (.pot) files.
+###
+### Do not add, change, or remove "msgid"s manually here as
+### they're tied to the ones in the corresponding POT file
+### (with the same domain).
+###
+### Use "mix gettext.extract --merge" or "mix gettext.merge"
+### to merge POT files into PO files.
+msgid ""
+msgstr ""
+"Language: en\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: lib/tourin_it_web/components/core_components.ex:492
+#, elixir-autogen, elixir-format
+msgid "Actions"
+msgstr ""
+
+#: lib/tourin_it_web/components/core_components.ex:160
+#, elixir-autogen, elixir-format
+msgid "Attempting to reconnect"
+msgstr ""
+
+#: lib/tourin_it_web/components/core_components.ex:151
+#, elixir-autogen, elixir-format
+msgid "Error!"
+msgstr ""
+
+#: lib/tourin_it_web/components/core_components.ex:172
+#, elixir-autogen, elixir-format
+msgid "Hang in there while we get back on track"
+msgstr ""
+
+#: lib/tourin_it_web/components/core_components.ex:167
+#, elixir-autogen, elixir-format
+msgid "Something went wrong!"
+msgstr ""
+
+#: lib/tourin_it_web/components/core_components.ex:150
+#, elixir-autogen, elixir-format
+msgid "Success!"
+msgstr ""
+
+#: lib/tourin_it_web/components/core_components.ex:155
+#, elixir-autogen, elixir-format
+msgid "We can't find the internet"
+msgstr ""
+
+#: lib/tourin_it_web/components/core_components.ex:76
+#: lib/tourin_it_web/components/core_components.ex:130
+#, elixir-autogen, elixir-format
+msgid "close"
+msgstr ""
+
+#: lib/tourin_it_web/live/tour_stop_live/index.html.heex:5
+#, elixir-autogen, elixir-format
+msgid "tour_stop.occasion"
+msgstr "Meal"

--- a/priv/repo/migrations/20250702212500_add_occasion_to_tour_stops.exs
+++ b/priv/repo/migrations/20250702212500_add_occasion_to_tour_stops.exs
@@ -1,0 +1,9 @@
+defmodule TourinIt.Repo.Migrations.AddOccasionToTourStops do
+  use Ecto.Migration
+
+  def change do
+    alter table("tour_stops") do
+      add :occasion, :string, null: false, default: "dinner"
+    end
+  end
+end

--- a/test/tourin_it/tour_stops_test.exs
+++ b/test/tourin_it/tour_stops_test.exs
@@ -51,6 +51,7 @@ defmodule TourinIt.TourStopsTest do
 
       assert {:ok, %TourStop{} = tour_stop} = TourStops.create_tour_stop(valid_attrs)
       assert tour_stop.destination == "some destination"
+      assert tour_stop.occasion == :dinner
       assert tour_stop.start_date == ~D[2025-05-09]
       assert tour_stop.end_date == ~D[2025-05-09]
 
@@ -108,12 +109,19 @@ defmodule TourinIt.TourStopsTest do
 
     test "update_tour_stop/2 with valid data updates the tour_stop" do
       tour_stop = tour_stop_fixture()
-      update_attrs = %{destination: "some updated destination", start_date: ~D[2025-05-10], end_date: ~D[2025-05-10]}
+
+      update_attrs = %{
+        destination: "some updated destination",
+        occasion: :breakfast,
+        start_date: ~D[2025-05-10],
+        end_date: ~D[2025-05-10]
+      }
 
       assert {:ok, %TourStop{}} = TourStops.update_tour_stop(%TourStop{id: tour_stop.id}, update_attrs)
 
       tour_stop = TourStops.get_tour_stop!(tour_stop.id)
       assert tour_stop.destination == "some updated destination"
+      assert tour_stop.occasion == :breakfast
       assert tour_stop.start_date == ~D[2025-05-10]
       assert tour_stop.end_date == ~D[2025-05-10]
     end


### PR DESCRIPTION
Adds an occasion enum field to TourStops.  This allows the organizer to denote a breakfast tour stop from a dinner tour stop.