### PR TITLE
Move occasion and destination inline in UI

### DIFF
--- a/lib/tourin_it_web/components/tour_stop_components.ex
+++ b/lib/tourin_it_web/components/tour_stop_components.ex
@@ -9,9 +9,8 @@ defmodule TourinItWeb.TourStopComponents do
       <p class="font-semibold mb-8 text-zinc-700">
         {format_date(@tour_stop.start_date)} - {format_date(@tour_stop.end_date)}
       </p>
-      <p class="font-semibold mb-2 text-zinc-700">{@tour_stop.destination}</p>
-      <p class="mb-8 text-zinc-500">
-        <.tour_stop_occasion occasion={@tour_stop.occasion} />
+      <p class="font-semibold mb-8 text-zinc-700">
+        <.tour_stop_occasion occasion={@tour_stop.occasion} /> @ {@tour_stop.destination}
       </p>
     """
   end


### PR DESCRIPTION
Moving occasion inline with destination to save vertical space

![image](https://github.com/user-attachments/assets/840a0b5b-fa01-49d7-a997-004301837348)
