### PR TITLE
Only show past and upcoming tour stops in the TourSession index view

### DIFF
--- a/lib/tourin_it/tour_stops.ex
+++ b/lib/tourin_it/tour_stops.ex
@@ -21,6 +21,16 @@ defmodule TourinIt.TourStops do
     Repo.one(query)
   end
 
+  def past_and_upcoming(tour_session_id) do
+    up = upcoming(tour_session_id)
+
+    query = from tour_stop in TourStop,
+      where: tour_stop.tour_session_id == ^tour_session_id and tour_stop.end_date <= ^up.end_date,
+      order_by: [desc: tour_stop.end_date]
+
+    Repo.all(query)
+  end
+
   @doc """
   Returns the list of tour_stops.
 

--- a/lib/tourin_it_web/live/tour_stop_live/index.ex
+++ b/lib/tourin_it_web/live/tour_stop_live/index.ex
@@ -4,7 +4,7 @@ defmodule TourinItWeb.TourStopLive.Index do
   import TourinItWeb.Access.TourGoer
   import TourinItWeb.TourStopComponents
 
-  alias TourinIt.{Organize, Repo}
+  alias TourinIt.{Organize, Repo, TourStops}
 
   on_mount {TourinItWeb.UserAuth, :mount_current_user}
 
@@ -12,13 +12,15 @@ defmodule TourinItWeb.TourStopLive.Index do
     tour_session = Organize.get_tour_session!(%{identifier: identifier, slug: slug})
     ensure_invited!(socket.assigns.current_user, tour_session)
 
-    tour_session = Repo.preload(tour_session, [:tour, :tour_stops])
+    tour_session = Repo.preload(tour_session, [:tour])
+    tour_stops = TourStops.past_and_upcoming(tour_session.id)
 
     socket =
       socket
       |> assign(:page_title, "#{tour_session.tour.name} #{tour_session.identifier}")
       |> assign(:tour, tour_session.tour)
       |> assign(:tour_session, tour_session)
+      |> assign(:tour_stops, tour_stops)
 
     {:ok, socket}
   end

--- a/lib/tourin_it_web/live/tour_stop_live/index.html.heex
+++ b/lib/tourin_it_web/live/tour_stop_live/index.html.heex
@@ -1,6 +1,6 @@
 <.header class="mb-8">{@tour.name} {@tour_session.identifier}</.header>
 
-<.table id="tour_stops" rows={@tour_session.tour_stops} row_click={&JS.navigate(~p"/tour_stops/#{&1}")}>
+<.table id="tour_stops" rows={@tour_stops} row_click={&JS.navigate(~p"/tour_stops/#{&1}")}>
   <:col :let={tour_stop} label="Location">{tour_stop.destination}</:col>
   <:col :let={tour_stop} label={gettext("tour_stop.occasion")}>
     <.tour_stop_occasion occasion={tour_stop.occasion} />

--- a/test/tourin_it/tour_stops_test.exs
+++ b/test/tourin_it/tour_stops_test.exs
@@ -29,6 +29,15 @@ defmodule TourinIt.TourStopsTest do
       assert TourStops.upcoming(tour_session.id) == tour_stop
     end
 
+    test "past_and_upcoming/1" do
+      tour_session = tour_session_fixture()
+      past_tour_stop = tour_stop_fixture(tour_session, %{end_date: Date.add(today(), -1)})
+      upcoming_tour_stop = tour_stop_fixture(tour_session, %{end_date: Date.add(today(), 1)})
+      _future_tour_stop = tour_stop_fixture(tour_session, %{end_date: Date.add(today(), 2)})
+
+      assert TourStops.past_and_upcoming(tour_session.id) == [upcoming_tour_stop, past_tour_stop]
+    end
+
     test "list_tour_stops/0 returns all tour_stops" do
       tour_stop = tour_stop_fixture()
       assert TourStops.list_tour_stops() == [tour_stop]


### PR DESCRIPTION
This allows the organizer to enter future stops without revealing them to tour goers